### PR TITLE
small updates for AEM docker image

### DIFF
--- a/aem/Dockerfile
+++ b/aem/Dockerfile
@@ -1,9 +1,12 @@
 FROM airdock/oracle-jdk:1.8
-MAINTAINER sii.pl
+
+LABEL maintainer=sii.pl
 
 WORKDIR /aem
 
-ARG AEM_RUNMODE
+# https://vsupalov.com/docker-build-time-env-values/
+ARG AEM_RUNMODE=author
+ENV CQ_RUNMODE=$AEM_RUNMODE
 
 COPY aem_packages/*.jar /aem/aem.jar
 COPY aem_packages/license.properties /aem/license.properties
@@ -17,7 +20,6 @@ RUN java -jar aem.jar -unpack -r nosamplecontent
 
 WORKDIR /aem/crx-quickstart/bin
 COPY ./scripts/run.sh /aem/crx-quickstart/bin/run.sh
-RUN echo "CQ_RUNMODE=\"${AEM_RUNMODE}\"" > config
 
 WORKDIR /aem/crx-quickstart
 COPY jstatd.all.policy /aem/crx-quickstart/jstatd.all.policy

--- a/aem/Dockerfile
+++ b/aem/Dockerfile
@@ -4,10 +4,6 @@ LABEL maintainer=sii.pl
 
 WORKDIR /aem
 
-# https://vsupalov.com/docker-build-time-env-values/
-ARG AEM_RUNMODE=author
-ENV CQ_RUNMODE=$AEM_RUNMODE
-
 COPY aem_packages/*.jar /aem/aem.jar
 COPY aem_packages/license.properties /aem/license.properties
 
@@ -25,6 +21,10 @@ WORKDIR /aem/crx-quickstart
 COPY jstatd.all.policy /aem/crx-quickstart/jstatd.all.policy
 COPY jstatd_run /aem/crx-quickstart/jstatd_run
 RUN chmod +x /aem/crx-quickstart/jstatd_run
+
+# https://vsupalov.com/docker-build-time-env-values/
+ARG AEM_RUNMODE=author
+ENV CQ_RUNMODE=$AEM_RUNMODE
 
 EXPOSE 80 10000 2000
 ENTRYPOINT ["/aem/crx-quickstart/bin/run.sh"]


### PR DESCRIPTION
Small updates for AEM docker image so it is possible to build it with default mode *author*.

ARG line was moved further in *Dockerfile* so that succesive builds are faster.

Switched to LABEL as [MAINTAINER is depreceted](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).

We don't need anything in *config* file [if there is environment variable `CQ_RUNMODE`](https://github.com/puradawid/aem-docker-infrastructure/blob/master/aem/scripts/run.sh#L108).